### PR TITLE
Implement accessible mobile navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,11 +145,23 @@
                 
                 <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button class="text-gray-700 hover:text-teal-600">
-                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <button id="mobile-menu-button" type="button" class="text-gray-700 hover:text-teal-600 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 focus:ring-offset-white" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open main menu">
+                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                         </svg>
                     </button>
+                </div>
+            </div>
+        </div>
+        <!-- Mobile menu -->
+        <div id="mobile-menu" class="md:hidden hidden">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="px-4 pt-2 pb-4 space-y-2 bg-white shadow-lg border border-gray-200 rounded-b-lg">
+                    <a href="#home" class="block rounded-lg px-3 py-2 text-base font-medium text-gray-900 hover:bg-teal-50 hover:text-teal-600 transition-colors">Home</a>
+                    <a href="services.html" class="block rounded-lg px-3 py-2 text-base font-medium text-gray-700 hover:bg-teal-50 hover:text-teal-600 transition-colors">Services</a>
+                    <a href="training.html" class="block rounded-lg px-3 py-2 text-base font-medium text-gray-700 hover:bg-teal-50 hover:text-teal-600 transition-colors">Training</a>
+                    <a href="about.html" class="block rounded-lg px-3 py-2 text-base font-medium text-gray-700 hover:bg-teal-50 hover:text-teal-600 transition-colors">About</a>
+                    <button type="button" class="w-full btn-primary px-6 py-2 rounded-lg text-base font-medium">Get Started</button>
                 </div>
             </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -576,13 +576,75 @@ function initSmoothScrolling() {
 
 // Mobile Menu
 function initMobileMenu() {
-    const mobileMenuButton = document.querySelector('.md\\:hidden button');
-    if (mobileMenuButton) {
-        mobileMenuButton.addEventListener('click', function() {
-            // Toggle mobile menu (simplified implementation)
-            alert('Mobile menu functionality would be implemented here');
+    const mobileMenuButton = document.getElementById('mobile-menu-button');
+    const mobileMenu = document.getElementById('mobile-menu');
+
+    if (!mobileMenuButton || !mobileMenu) return;
+
+    const focusableMenuItems = mobileMenu.querySelectorAll('a, button');
+
+    const isMenuOpen = () => !mobileMenu.classList.contains('hidden');
+
+    const openMenu = () => {
+        mobileMenu.classList.remove('hidden');
+        mobileMenu.classList.add('block');
+        mobileMenuButton.setAttribute('aria-expanded', 'true');
+        mobileMenuButton.setAttribute('aria-label', 'Close main menu');
+
+        if (focusableMenuItems.length > 0) {
+            focusableMenuItems[0].focus();
+        }
+    };
+
+    const closeMenu = ({ focusButton = false } = {}) => {
+        mobileMenu.classList.add('hidden');
+        mobileMenu.classList.remove('block');
+        mobileMenuButton.setAttribute('aria-expanded', 'false');
+        mobileMenuButton.setAttribute('aria-label', 'Open main menu');
+
+        if (focusButton) {
+            mobileMenuButton.focus();
+        }
+    };
+
+    const toggleMenu = () => {
+        if (isMenuOpen()) {
+            closeMenu({ focusButton: true });
+        } else {
+            openMenu();
+        }
+    };
+
+    mobileMenuButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+        toggleMenu();
+    });
+
+    mobileMenu.addEventListener('click', (event) => {
+        event.stopPropagation();
+    });
+
+    document.addEventListener('click', (event) => {
+        if (!isMenuOpen()) return;
+
+        if (!mobileMenu.contains(event.target) && event.target !== mobileMenuButton) {
+            closeMenu();
+        }
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && isMenuOpen()) {
+            closeMenu({ focusButton: true });
+        }
+    });
+
+    focusableMenuItems.forEach(item => {
+        item.addEventListener('click', () => {
+            if (isMenuOpen()) {
+                closeMenu();
+            }
         });
-    }
+    });
 }
 
 // Utility function for button clicks


### PR DESCRIPTION
## Summary
- add accessible mobile navigation markup and toggle button semantics to the landing page
- replace the placeholder mobile menu handler with an accessible toggle, focus management, and outside-click behavior

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e275cc0db48325a2fbc3914569532d